### PR TITLE
Update Ruby version to 2.4 to reflect Github Workflow version

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@
 bootstrap:
 	# assumptions:
 	# - a ruby environment
-	echo "2.3.0" > .ruby-version
+	echo "2.4" > .ruby-version
 	gem install bundler
 	bundle install
 setup: bootstrap


### PR DESCRIPTION
@zefram-cochrane I noticed the makefile still had version 2.3 in it; this should be version 2.4.

Ruby 2.3 still works, but it is deprecated on most modern Linux distros and build infra, so I recommend using 2.4.

Tested on the Github build server and on my machine.