### PR TITLE
Refactor social links into a partial

### DIFF
--- a/source/directory/tag.html.slim
+++ b/source/directory/tag.html.slim
@@ -31,18 +31,6 @@ blog: directory
               <img src="../#{article.data.image}" class="person-thumbnail">
               = article.summary
               a href=article.url Read More ...
-              ul.icons
-                li
-                  a.icon.alt.fa-twitter href="#{article.data.twitter}" 
-                    span.label Twitter
-                li
-                  a.icon.alt.fa-linkedin href="#{article.data.linkedin}" 
-                    span.label LinkedIn
-                li
-                  a.icon.alt.fa-github href="#{article.data.github}" 
-                    span.label GitHub
-                li
-                  a.icon.alt.fa-envelope href="#{article.data.contact}" 
-                    span.label Email
+              = partial('partials/social-links', :locals => { :context => article } )
               hr
 

--- a/source/layouts/person.slim
+++ b/source/layouts/person.slim
@@ -8,22 +8,10 @@
           section#sidebar
             section
               <img src="#{current_page.data.image}">
-              ul.icons
-                li
-                  a.icon.alt.fa-twitter href="#{current_page.data.twitter}" 
-                    span.label Twitter
-                li
-                  a.icon.alt.fa-linkedin href="#{current_page.data.linkedin}" 
-                    span.label LinkedIn
-                li
-                  a.icon.alt.fa-github href="#{current_page.data.github}" 
-                    span.label GitHub
-                li
-                  a.icon.alt.fa-envelope href="#{current_page.data.contact}" 
-                    span.label Email
+              = partial('partials/social-links')
         div class=("8u$ 12u$(medium) important(medium)") 
           /! Content
-          <article>
+          article
             h2 #{current_page.data.title}
             ul.actions
               - current_page.tags.each do |tag|
@@ -31,9 +19,5 @@
                   a href="./tags/#{tag}.html" #{tag}
                   
             == yield
-            ul.actions
-              li <a href="#{current_page.data.linkedin}">LinkedIn</a>
-              li <a href="#{current_page.data.github}">Github</a>
-              li <a href="#{current_page.data.twitter}">Twitter</a>
-              li <a href="#{current_page.data.contact}">Contact</a>
-          </article>
+
+            = partial('partials/social-links')

--- a/source/partials/_social-links.slim
+++ b/source/partials/_social-links.slim
@@ -1,0 +1,16 @@
+ruby:
+  context ||= current_page
+
+ul.icons
+  li
+    a.icon.alt.fa-twitter href="#{context.data.twitter}" 
+      span.label Twitter
+  li
+    a.icon.alt.fa-linkedin href="#{context.data.linkedin}" 
+      span.label LinkedIn
+  li
+    a.icon.alt.fa-github href="#{context.data.github}" 
+      span.label GitHub
+  li
+    a.icon.alt.fa-envelope href="#{context.data.contact}" 
+      span.label Email

--- a/source/partials/_social-links.slim
+++ b/source/partials/_social-links.slim
@@ -2,15 +2,19 @@ ruby:
   context ||= current_page
 
 ul.icons
-  li
-    a.icon.alt.fa-twitter href="#{context.data.twitter}" 
-      span.label Twitter
-  li
-    a.icon.alt.fa-linkedin href="#{context.data.linkedin}" 
-      span.label LinkedIn
-  li
-    a.icon.alt.fa-github href="#{context.data.github}" 
-      span.label GitHub
-  li
-    a.icon.alt.fa-envelope href="#{context.data.contact}" 
-      span.label Email
+  - if context.data.twitter
+    li
+      a.icon.alt.fa-twitter href="#{context.data.twitter}" 
+        span.label Twitter
+  - if context.data.linkedin
+    li
+      a.icon.alt.fa-linkedin href="#{context.data.linkedin}" 
+        span.label LinkedIn
+  - if context.data.github
+    li
+      a.icon.alt.fa-github href="#{context.data.github}" 
+        span.label GitHub
+  - if context.data.contact
+    li
+      a.icon.alt.fa-envelope href="#{context.data.contact}" 
+        span.label Email


### PR DESCRIPTION
A person's social links are displayed on multiple pages. Before this PR, the code was duplicated. After this refactoring, I could very easily implement conditional rendering of social links. Now, social links are only shown if the accompanying data was provided. See the image below for an example:

![image](https://user-images.githubusercontent.com/285398/73941221-24cbb380-48ed-11ea-8d3b-738d9dbf0d02.png)


