### PR TITLE
Peters coach page - with Corsizio course offering

### DIFF
--- a/source/directory/2015-peter-merel.html.markdown
+++ b/source/directory/2015-peter-merel.html.markdown
@@ -15,7 +15,15 @@ linkedin: https://www.linkedin.com/in/petermerel/
 github: https://github.com/zefram-cochrane
 twitter:
 contact:
+corsizio_instructor_id: 5ce14dbc1a64e29f18d7e7c6
+
 ---
 
 <!-- Write your personal summary below. You can use Markdown formatting. -->
-Peter Merel has been a professional programmer for over 40 years. His software products control a third of the world's oil infrastructure as well as most of Australia's international telecommunications network. He ran the second XP project in the 90s, was credited in the first XP book, keynoted the first XP conference, invented the first agile training game, and wrote the first open source wiki-engine, which served the first version of Wikipedia. 5 years ago he founded the XSCALE Alliance, a Gartner-recognised Linux-style ecosystem of independent agnostic agilists that integrates DevOps with Descaling, Business Agility, and Breadth-First Product Management.
+Peter Merel has been a professional programmer for over 40 years. 
+His software products control a third of the world's oil infrastructure as well as most of Australia's international telecommunications network. 
+He ran the second XP project in the 90s, was credited in the first XP book, 
+keynoted the first XP conference, invented the first agile training game, 
+and wrote the first open source wiki-engine, which served the first version of Wikipedia. 
+
+5 years ago he founded the XSCALE Alliance, a Gartner-recognised Linux-style ecosystem of independent agnostic agilists that integrates DevOps with Descaling, Business Agility, and Breadth-First Product Management.

--- a/source/directory/2019-marijn-van-der-zee.html.markdown
+++ b/source/directory/2019-marijn-van-der-zee.html.markdown
@@ -13,6 +13,7 @@ linkedin: 'https://www.linkedin.com/in/marijnvanderzee'
 github: 'https://github.com/serra'
 twitter: 'https://twitter.com/marijnvanderzee'
 contact: 'https://www.serraict.com/pages/contact'
+corsizio_instructor_id: 5ec79c159b4f72a40d91e169
 
 ---
 

--- a/source/layouts/person.slim
+++ b/source/layouts/person.slim
@@ -21,3 +21,5 @@
             == yield
 
             = partial('partials/social-links')
+
+            = partial('partials/courses')

--- a/source/partials/_courses.slim
+++ b/source/partials/_courses.slim
@@ -1,0 +1,7 @@
+ruby:
+  context ||= current_page
+
+<h3>Courses by #{context.data.title}</h3>
+
+<script>window.addEventListener('message',function(e){if(!e.data.corsizio)return;var f=document.getElementById('CS_portal_5ce14dbc1a64e24f3fd7e7b7');e.data.height>=0&&(f.height=e.data.height+'px');e.data.scrollTo>=0&&window.scrollTo(0,e.data.scrollTo);e.data.scrollIntoView&&f.scrollIntoView();});</script>
+<iframe id="CS_portal_5ce14dbc1a64e24f3fd7e7b7" src="https://xscale.corsizio.com?embed=noheader,notoolbar,nophotos,nomessages,nosocial,nopadding,plain,newtab,nocalendar&instructor=#{context.data.corsizio_instructor_id || -1}" width="100%" height="100%" frameborder="0"></iframe>


### PR DESCRIPTION
Given an XSCALE coach `corsizio instructor id`
When I navigate to a coach's profile page
Then I see this coach's `course offerings`

Examples:

 * [x] Peter (id: 5ce14dbc1a64e29f18d7e7c6), a coach configured in Corsizio, with several courses planned shows this list 
 * [x] Marijn (id: 5ec79c159b4f72a40d91e169), a coach with no courses, shows an empty list
 * [x] Gideon (id: empty), a coach without a Corizio account, shows an empty list (does not require any configuration, just leave out the corsizio id from the metadata)